### PR TITLE
Expose

### DIFF
--- a/compose/attribute.go
+++ b/compose/attribute.go
@@ -43,7 +43,7 @@ func InitServicesAttributes() []Attribute {
 		},
 		{
 			Name:             "ports",
-                        InputDescription: "Expose ports, publish/map to host (HOST_PORT:CONTAINER_PORT)",
+			InputDescription: "Expose ports, publish/map to host (HOST_PORT:CONTAINER_PORT)",
 			Example:          "8000:8000",
 			IsList:           true,
 			Category:         servicesCategory,

--- a/compose/attribute.go
+++ b/compose/attribute.go
@@ -43,8 +43,15 @@ func InitServicesAttributes() []Attribute {
 		},
 		{
 			Name:             "ports",
-			InputDescription: "Expose ports",
+                        InputDescription: "Expose ports, publish/map to host (HOST_PORT:CONTAINER_PORT)",
 			Example:          "8000:8000",
+			IsList:           true,
+			Category:         servicesCategory,
+		},
+                {
+			Name:             "expose",
+			InputDescription: "Expose ports, not published/mapped to host",
+			Example:          "8000",
 			IsList:           true,
 			Category:         servicesCategory,
 		},

--- a/compose/attribute.go
+++ b/compose/attribute.go
@@ -48,7 +48,7 @@ func InitServicesAttributes() []Attribute {
 			IsList:           true,
 			Category:         servicesCategory,
 		},
-                {
+		{
 			Name:             "expose",
 			InputDescription: "Expose ports, not published/mapped to host",
 			Example:          "8000",


### PR DESCRIPTION
Add "expose" attribute to expose ports with Docker and not published/mapped to host.
Updated description of "ports" attribute to differentiate from "expose".